### PR TITLE
Fix Skyfield time step calculations

### DIFF
--- a/backend/collision_checker.py
+++ b/backend/collision_checker.py
@@ -9,7 +9,11 @@ def check_collisions(satellites, threshold_km=10, minutes=60, step_seconds=30):
     """
     ts = load.timescale()
     t0 = ts.now()
-    time_steps = [t0 + i * step_seconds for i in range((minutes * 60) // step_seconds)]
+    # Skyfield Time objects treat addition as days, so convert step_seconds
+    # from seconds to fractional days before adding.
+    seconds_per_day = 86400
+    time_steps = [t0 + (i * step_seconds) / seconds_per_day
+                  for i in range((minutes * 60) // step_seconds)]
 
     print(f"Checking {len(satellites)} satellites for next {minutes} minutes...")
 

--- a/backend/orbit_plotter.py
+++ b/backend/orbit_plotter.py
@@ -8,7 +8,11 @@ def plot_satellite_orbits_3d(satellites, minutes=30, step_seconds=60):
     """
     ts = load.timescale()
     t0 = ts.now()
-    time_steps = [t0 + i * step_seconds for i in range((minutes * 60) // step_seconds)]
+    # Convert step_seconds from seconds to days when adding to the Skyfield Time
+    # object, otherwise each step would advance by that many **days**.
+    seconds_per_day = 86400
+    time_steps = [t0 + (i * step_seconds) / seconds_per_day
+                  for i in range((minutes * 60) // step_seconds)]
 
     plotter = pv.Plotter(window_size=(1000, 700))
     plotter.set_background("black")

--- a/backend/visualizer.py
+++ b/backend/visualizer.py
@@ -51,7 +51,10 @@ def plot_animated_positions(satellites):
     """
     ts = load.timescale()
     t0 = ts.now()
-    time_steps = [t0 + i * 1 for i in range(120)]  # 2 minutes, 1s interval
+    # Generate 120 time steps spaced 1 second apart. Since Skyfield uses days as
+    # the time unit, convert the step from seconds to days before adding.
+    seconds_per_day = 86400
+    time_steps = [t0 + i / seconds_per_day for i in range(120)]  # 2 minutes
 
     names = [sat.name for sat in satellites[:10]]
     positions = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+skyfield

--- a/tests/test_time_steps.py
+++ b/tests/test_time_steps.py
@@ -1,0 +1,11 @@
+from skyfield.api import load
+
+SECONDS_PER_DAY = 86400
+
+def test_time_step_spacing():
+    ts = load.timescale()
+    t0 = ts.now()
+    step = 15  # seconds
+    time_steps = [t0 + (i * step) / SECONDS_PER_DAY for i in range(2)]
+    delta_seconds = (time_steps[1].tt - time_steps[0].tt) * SECONDS_PER_DAY
+    assert abs(delta_seconds - step) < 1e-6


### PR DESCRIPTION
## Summary
- use fractional day increments when generating Skyfield `Time` arrays
- update orbit plotter, collision checker and visualizer
- add basic regression test for time step spacing
- add minimal requirements file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fddf64d1483278472eb824f34e065