### PR TITLE
Fix time step conversion

### DIFF
--- a/backend/collision_checker.py
+++ b/backend/collision_checker.py
@@ -11,8 +11,8 @@ def check_collisions(satellites, threshold_km=10, minutes=60, step_seconds=30):
     t0 = ts.now()
     # Skyfield Time objects treat addition as days, so convert step_seconds
     # from seconds to fractional days before adding.
-    seconds_per_day = 86400
-    time_steps = [t0 + (i * step_seconds) / seconds_per_day
+    step_days = step_seconds / 86400
+    time_steps = [t0 + i * step_days
                   for i in range((minutes * 60) // step_seconds)]
 
     print(f"Checking {len(satellites)} satellites for next {minutes} minutes...")


### PR DESCRIPTION
## Summary
- fix handling of `step_seconds` when generating time steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848568faf8c83278af6a6b1f8e106f7